### PR TITLE
Release v5.3.2 caseless names

### DIFF
--- a/netfoundry/demo.py
+++ b/netfoundry/demo.py
@@ -15,7 +15,6 @@ from .organization import Organization
 from .network_group import NetworkGroup
 from .network import Network
 from .utility import (DC_PROVIDERS, Utility)
-from .utility import Utility
 
 def main():
     """Run the demo script."""

--- a/netfoundry/network_group.py
+++ b/netfoundry/network_group.py
@@ -1,7 +1,6 @@
 import json
 
-from .utility import RESOURCES, STATUS_CODES, eprint, http
-
+from .utility import (RESOURCES, STATUS_CODES, eprint, http, Utility)
 
 class NetworkGroup:
     """use a Network Group by name or ID.
@@ -51,10 +50,8 @@ class NetworkGroup:
         else:
             self.nfconsole = "https://{vanity}.{env}-nfconsole.io".format(vanity=self.vanity, env=self.session.environment)
 
-    def nc_data_centers(self): # this was attribute self.nc_data_centers and converted to method to avoid calling preemptively with self.__init__
-        return(self.get_controller_data_centers())
-
-    def nc_data_centers_by_location(self): # this was attribute self.nc_data_centers_by_location and converted to method to avoid calling preemptively with self.__init__
+    def nc_data_centers_by_location(self):
+        """Get a controller data center by locationCode."""
         my_nc_data_centers_by_location = dict()
         for dc in self.get_controller_data_centers():
             my_nc_data_centers_by_location[dc['locationCode']] = dc['id']
@@ -62,15 +59,19 @@ class NetworkGroup:
         return(my_nc_data_centers_by_location)
 
     # resolve network UUIDs by name
-    def networks_by_name(self): # this was attribute self.networks_by_name and converted to method to avoid calling preemptively with self.__init__
+    def networks_by_name(self):
+        """Find networks in group by normalized name.
+        
+        Normalize a search term by calling "Utility.normalize_caseless(text)".
+        """
+        utility = Utility()
         my_networks_by_name = dict()
         for net in self.session.get_networks_by_group(self.network_group_id):
-            my_networks_by_name[net['name']] = net['id']
+            my_networks_by_name[utility.normalize_caseless(net['name'])] = net['id']
         return(my_networks_by_name)
 
     def get_controller_data_centers(self):
-        """list the data centers where a Network Controller may be created
-        """
+        """Find controller data centers."""
         try:
             # data centers returns a list of dicts (data center objects)
             headers = { "authorization": "Bearer " + self.session.token }
@@ -108,9 +109,11 @@ class NetworkGroup:
 
         return(aws_data_centers)
 
+    # provide a compatible alias
+    nc_data_centers = get_controller_data_centers
+
     def get_product_metadata(self, is_active: bool=True):
-        """fetch all product metadata
-        """
+        """Get all products' metadata."""
         try:
             response = http.get(
                 self.session.audience+'product-metadata/v2/download-urls.json',
@@ -146,8 +149,7 @@ class NetworkGroup:
             return (product_metadata)
 
     def list_product_versions(self, product_metadata: dict={}):
-        """find all product version from product metadata
-        """
+        """Find product versions in all products' metadata."""
         if product_metadata:
             product_versions = product_metadata.keys()
         else:
@@ -157,8 +159,7 @@ class NetworkGroup:
         return (product_versions)
 
     def find_latest_product_version(self, product_versions: list=[]):
-        """find the highest sorted product version number (may be experimental, not stable)
-        """
+        """Get the highest product version number (may be experimental, not stable)."""
         if not product_versions:
             product_versions = self.list_product_versions()
 
@@ -167,14 +168,14 @@ class NetworkGroup:
 
     def create_network(self, name: str, network_group_id: str=None, location: str="us-east-1", version: str=None, size: str="small"):
         """
-        create a network with
+        Create a network in this network group.
+
         :param name: required network name
         :param network_group: optional Network Group ID
         :param location: optional data center region name in which to create
         :param version: optional product version string like 7.3.17
         :param size: optional network configuration metadata name from /core/v2/network-configs e.g. "medium"
         """
-        
         my_nc_data_centers_by_location = self.nc_data_centers_by_location()
         if not location in my_nc_data_centers_by_location.keys():
             raise Exception("ERROR: unexpected Network location '{:s}'. Valid locations include: {}.".format(location, my_nc_data_centers_by_location.keys()))
@@ -243,9 +244,10 @@ class NetworkGroup:
 
     def delete_network(self, network_id=None, network_name=None):
         """
-        delete a Network
-        :param id: optional Network UUID to delete
-        :param name: optional Network name to delete
+        Delete a network.
+
+        :param id: optional network UUID to delete
+        :param name: optional network name to delete
         """
         try:
             networks_by_name = self.networks_by_name()

--- a/netfoundry/utility.py
+++ b/netfoundry/utility.py
@@ -19,22 +19,30 @@ class Utility:
         pass
 
     def camel(self, snake_str):
+        """Convert a string from snake case to camel case."""
         first, *others = snake_str.split('_')
         return ''.join([first.lower(), *map(str.title, others)])
 
     def snake(self, camel_str):
+        """Convert a string from camel case to snake case."""
         return sub(r'(?<!^)(?=[A-Z])', '_', camel_str).lower()
 
     def normalize_caseless(self, text):
+        """Normalize a string as lowercase unicode KD form.
+        
+        The normal form KD (NFKD) will apply the compatibility decomposition,
+        i.e. replace all compatibility characters with their equivalents.
+        """
         return unicodedata.normalize("NFKD", text.casefold())
 
     def caseless_equal(self, left, right):
+        """Compare the KD normal form of left, right strings."""
         return self.normalize_caseless(left) == self.normalize_caseless(right)
 
 class LookupDict(dict):
     """Dictionary lookup object."""
-
     def __init__(self, name=None):
+        """Initialize a lookup dictionary."""
         self.name = name
         super(LookupDict, self).__init__()
 


### PR DESCRIPTION
Python string comparisons are case-sensitive by default, and display names of entities in the NF API are enforced caseless (case-insensitive) unique per domain. 

These changes enable and illustrate caseless comparisons according to the unicode KD normal form which for most English words will appear simply as lowercase (case-folded to-lower).

This is useful, as illustrated in the demo script, for determining whether there is already a name with any case before attempting to create an entity with the same name of a different case.