### PR TITLE
Release v5.9.4 fix query param collision and describe Ziti-backed resource types

### DIFF
--- a/netfoundry/ctl.py
+++ b/netfoundry/ctl.py
@@ -540,7 +540,7 @@ def get(cli, echo: bool = True, spinner: object = None):
                         cli.log.warn(f"using 'id' only, ignoring params: '{', '.join(query_keys)}'")
                     match = network.get_resource_by_id(type=cli.args.resource_type, id=cli.args.query['id'], accept=cli.args.accept)
                 else:
-                    matches = network.find_resources(type=cli.args.resource_type, accept=cli.args.accept, **cli.args.query)
+                    matches = network.find_resources(type=cli.args.resource_type, accept=cli.args.accept, params=cli.args.query)
                     if len(matches) == 1:
                         match = matches[0]
 
@@ -669,7 +669,7 @@ def list(cli, spinner: object = None):
             if cli.args.resource_type == "data-centers":
                 matches = network.find_edge_router_data_centers(**cli.args.query)
             else:
-                matches = network.find_resources(type=cli.args.resource_type, accept=cli.args.accept, **cli.args.query)
+                matches = network.find_resources(type=cli.args.resource_type, accept=cli.args.accept, params=cli.args.query)
 
     if len(matches) == 0:
         spinner.fail(f"Found no {cli.args.resource_type} by '{', '.join(query_keys)}'")

--- a/netfoundry/network.py
+++ b/netfoundry/network.py
@@ -383,7 +383,7 @@ class Network:
         return(resource)
     get_resource = get_resource_by_id
 
-    def find_resources(self, type: str, accept: str = None, deleted: bool = False, **kwargs):
+    def find_resources(self, type: str, accept: str = None, deleted: bool = False, params: dict = dict(), **kwargs):
         """Find resources by type.
 
         :param str type: plural of an entity type in the network domain e.g. networks, endpoints, services, posture-checks, etc...
@@ -399,7 +399,6 @@ class Network:
         if type == "data-centers":
             self.logger.warn("don't call network.get_resources() for data centers, always use network.get_edge_router_data_centers() to filter for locations that support this network's version")
 
-        params = dict()
         for param in kwargs.keys():
             params[param] = kwargs[param]
         if not plural(type) == 'networks':

--- a/netfoundry/utility.py
+++ b/netfoundry/utility.py
@@ -484,9 +484,8 @@ class ResourceTypeParent:
 class ResourceType(ResourceTypeParent):
     """Typed resource type spec.
 
-    As close as I could get to a Go struct. This helps us to suggest possible
-    operations such as all resource types in the network domain that can be
-    mutated (C_UD).
+    This helps the CLI to suggest possible operations such as all resource
+    types in the network domain that can be mutated (C_UD).
     """
 
     name: str                                               # plural form as kebab-case e.g. edge-routers

--- a/netfoundry/utility.py
+++ b/netfoundry/utility.py
@@ -436,7 +436,7 @@ class Utility:
 
 
 NET_RESOURCES = dict()             # resources in network domain
-ZITI_NET_RESOURCES = dict()     # network resources that can be updated
+ZITI_NET_RESOURCES = dict()        # network resources that are backed 1:1 by a zitiId
 MUTABLE_NET_RESOURCES = dict()     # network resources that can be updated
 MUTABLE_RESOURCE_ABBREV = dict()   # unique abbreviations for ^
 EMBED_NET_RESOURCES = dict()       # network resources that may be fetched as embedded collections

--- a/netfoundry/utility.py
+++ b/netfoundry/utility.py
@@ -436,6 +436,7 @@ class Utility:
 
 
 NET_RESOURCES = dict()             # resources in network domain
+ZITI_NET_RESOURCES = dict()     # network resources that can be updated
 MUTABLE_NET_RESOURCES = dict()     # network resources that can be updated
 MUTABLE_RESOURCE_ABBREV = dict()   # unique abbreviations for ^
 EMBED_NET_RESOURCES = dict()       # network resources that may be fetched as embedded collections
@@ -508,6 +509,7 @@ class ResourceType(ResourceTypeParent):
     abbreviation: str = field(default='default')
     status_symbols: dict = field(default_factory=lambda: RESOURCE_STATUS_SYMBOLS)  # dictionary with three predictable keys: complete, progress, error, each a tuple associating status symbols with a state
     host: bool = field(default=False)                       # may have a managed host in NF cloud
+    ziti: bool = field(default=False)
 
     def __post_init__(self):
         """Compute and assign _embedded if not supplied and then check types in parent class."""
@@ -533,6 +535,8 @@ class ResourceType(ResourceTypeParent):
             if self.host:
                 HOSTABLE_NET_RESOURCES[self.name] = self
                 HOSTABLE_RESOURCE_ABBREV[self.abbreviation] = self
+            if self.ziti:
+                ZITI_NET_RESOURCES[self.name] = self
         return super().__post_init__()
 
 
@@ -649,7 +653,9 @@ RESOURCES = {
             "attributes": [],
             "enrollmentMethod": {"ott": True},
             "name": "Name"
-        }),
+        },
+        ziti=True,
+        ),
     'edge-routers': ResourceType(
         name='edge-routers',
         domain='network',
@@ -658,6 +664,7 @@ RESOURCES = {
         no_update_props=['registration'],
         create_responses=["ACCEPTED"],
         host=True,
+        ziti=True,
     ),
     'edge-router-policies': ResourceType(
         name='edge-router-policies',
@@ -672,6 +679,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
     'service-policies': ResourceType(
         name='service-policies',
@@ -679,6 +687,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
     'app-wans': ResourceType(
         name='app-wans',
@@ -694,6 +703,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
     'posture-checks': ResourceType(
         name='posture-checks',
@@ -701,6 +711,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
     'certificate-authorities': ResourceType(
         name='certificate-authorities',
@@ -708,6 +719,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
     'config-types': ResourceType(
         name='config-types',
@@ -715,6 +727,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
     'configs': ResourceType(
         name='configs',
@@ -722,6 +735,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
     'terminators': ResourceType(
         name='terminators',
@@ -729,6 +743,7 @@ RESOURCES = {
         mutable=True,
         embeddable=True,
         create_responses=["ACCEPTED"],
+        ziti=True,
     ),
 }
 


### PR DESCRIPTION
calling `network.find_resources(type='service-policy', **params)` raised `TypeError` when `params: {'type': 'Dial'}` because two keyword args 'type' are present. 

This patch adds 'params' keyword arg to nest arbitrary query params so they do not collide with function params.