### PR TITLE
Release v5.9.5 fix bug where PATCH operations silently fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
           general.yes=True \
           general.verbose=yes || true # FIXME: sometimes config command exits with an error
         nfctl demo \
+          --size medium \
           --regions us-west-2 us-east-2 \
           --provider AWS
         nfctl \

--- a/netfoundry/ctl.py
+++ b/netfoundry/ctl.py
@@ -838,7 +838,7 @@ def delete(cli):
 @cli.argument("-p", "--prefix", default=f"{cli.prog_name}-demo", help="choose a network name prefix to identify all of your demos")
 @cli.argument("-j", "--jwt", action="store_boolean", default=True, help="save the one-time enroll token for each demo identity in the current directory")
 @cli.argument("-e", "--echo-name", arg_only=True, action="store_true", default=False, help="only echo a friendly network name then exit")
-@cli.argument("-s", "--size", default="small", help=argparse.SUPPRESS)   # troubleshoot scale-up instance size factor
+@cli.argument("-s", "--size", default="medium", help=argparse.SUPPRESS)   # troubleshoot scale-up instance size factor
 @cli.argument("-v", "--product-version", default="default", help="network product version: 'default', 'latest', or any active semver")
 @cli.argument("--provider", default="AWS", help="cloud provider for hosted edge routers", choices=DC_PROVIDERS)
 @cli.argument("--regions", dest="regions", default=["us-west-1"], nargs="+", help="provider regions for hosted edge routers")

--- a/netfoundry/network.py
+++ b/netfoundry/network.py
@@ -507,19 +507,19 @@ class Network:
             else:
                 raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[after_response_code][0].upper()} ({after_response_code}) for patch: {json.dumps(patch, indent=2)}")
 
-            if resource.get('_links') and resource['_links'].get('process-executions'):
+            if resource.get('_links') and resource['_links'].get('executions'):
                 self.logger.debug("patch response has links, looking for process to track progress")
-                _links = resource['_links'].get('process-executions')
+                _links = resource['_links'].get('executions')
                 if isinstance(_links, list):
                     process_id = _links[0]['href'].split('/')[6]
                 else:
                     process_id = _links['href'].split('/')[6]
                 self.logger.debug(f"found async update process_id '{process_id}'")
                 if wait:
-                    self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                    self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                     return(resource)
                 else:    # only wait for the process to start, not finish, or timeout
-                    self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                    self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                     return(resource)
             elif wait:
                 self.logger.warn(f"unable to wait for async complete because response did not provide a process execution id, returning patched resource '{resource}'")
@@ -573,17 +573,17 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) for put: {json.dumps(put, indent=2)}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -618,18 +618,18 @@ class Network:
         else:
             resource = response.json()
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 resource = self.get_resource_by_id(type=type, id=resource['id'])
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -685,18 +685,18 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 resource = self.get_resource_by_id(type='endpoint', id=resource['id'])
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -780,20 +780,20 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) and response {response.text}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 if tunneler_enabled:
                     self.wait_for_entity_name_exists(entity_name=name, entity_type="endpoint", wait=wait)
                 resource = self.get_resource_by_id(type="edge-router", id=resource['id'])
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -986,17 +986,17 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) and response {response.text}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -1067,17 +1067,17 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) and response {response.text}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -1139,17 +1139,17 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) and response {response.text}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -1228,17 +1228,17 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) and response {response.text}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -1531,17 +1531,17 @@ class Network:
         else:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) and response {response.text}")
 
-        if resource.get('_links') and resource['_links'].get('process-executions'):
-            _links = resource['_links'].get('process-executions')
+        if resource.get('_links') and resource['_links'].get('executions'):
+            _links = resource['_links'].get('executions')
             if isinstance(_links, list):
                 process_id = _links[0]['href'].split('/')[6]
             else:
                 process_id = _links['href'].split('/')[6]
             if wait:
-                self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                 return(resource)
             else:    # only wait for the process to start, not finish, or timeout
-                self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                 return(resource)
         elif wait:
             self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -1970,17 +1970,17 @@ class Network:
                 self.logger.debug("ignoring {e}")
                 return(True)
             else:
-                if resource.get('_links') and resource['_links'].get('process-executions'):
-                    _links = resource['_links'].get('process-executions')
+                if resource.get('_links') and resource['_links'].get('executions'):
+                    _links = resource['_links'].get('executions')
                     if isinstance(_links, list):
                         process_id = _links[0]['href'].split('/')[6]
                     else:
                         process_id = _links['href'].split('/')[6]
                     if wait:
-                        self.wait_for_statuses(expected_statuses=RESOURCES["process-executions"].status_symbols['complete'], type="process-executions", id=process_id, wait=wait, sleep=sleep)
+                        self.wait_for_statuses(expected_statuses=RESOURCES["executions"].status_symbols['complete'], type="executions", id=process_id, wait=wait, sleep=sleep)
                         return(True)
                     else:    # only wait for the process to start, not finish, or timeout
-                        self.wait_for_statuses(expected_statuses=RESOURCES['process-executions'].status_symbols['progress'] + RESOURCES['process-executions'].status_symbols['complete'], type="process-executions", id=process_id, wait=9, sleep=2)
+                        self.wait_for_statuses(expected_statuses=RESOURCES['executions'].status_symbols['progress'] + RESOURCES['executions'].status_symbols['complete'], type="executions", id=process_id, wait=9, sleep=2)
                         return(True)
                 elif wait:
                     self.logger.warn("unable to wait for async complete because response did not provide a process execution id")
@@ -2064,7 +2064,7 @@ class Networks:
         resource = get_generic_resource(url=url, headers=headers, proxies=self.proxies, verify=self.verify, **params)
         return(resource)
 
-    def wait_for_process(self, process_id: str, expected_statuses: list, wait: int = 300, sleep: int = 3, id: str = None):
+    def wait_for_execution(self, process_id: str, expected_statuses: list, wait: int = 300, sleep: int = 3, id: str = None):
         """Continuously poll for the expected statuses until expiry.
 
         :param expected_statuses: list of strings as expected status symbol(s) e.g. ["PROVISIONING","PROVISIONED"]
@@ -2077,7 +2077,7 @@ class Networks:
         unexpected_statuses = PROCESS_STATUS_SYMBOLS['error']
         self.logger.debug(f"waiting for any status in {expected_statuses} for {type} with id {id} or until {time.ctime(now+wait)}.")
         status = 'NEW'
-        url = f"{self.audience}core/v2/process-executions/{process_id}"
+        url = f"{self.audience}core/v2/executions/{process_id}"
         headers = {"authorization": "Bearer " + self.token}
         time.sleep(sleep)                          # allow minimal time for the resource status to become available
         while time.time() < now+wait and status not in expected_statuses:
@@ -2096,3 +2096,4 @@ class Networks:
             raise RuntimeError(f"failed to read status while waiting for any status in {expected_statuses}; got {entity_status['http_status']} ({entity_status['response_code']})")
         else:
             raise RuntimeError(f"timed out with status {status} while waiting for any status in {expected_statuses}")
+    wait_for_process = wait_for_execution

--- a/netfoundry/network.py
+++ b/netfoundry/network.py
@@ -466,7 +466,7 @@ class Network:
         # compare the patch to the discovered, current state, adding new or updated keys to pruned_patch
         pruned_patch = dict()
         for k in patch.keys():
-            if k not in RESOURCES[plural(type)].no_update_props and k not in before_resource.keys():
+            if k not in RESOURCES[plural(type)].no_update_props and k in before_resource.keys():
                 if isinstance(patch[k], list):
                     if not set(before_resource[k]) == set(patch[k]):
                         pruned_patch[k] = list(set(patch[k]))

--- a/netfoundry/network.py
+++ b/netfoundry/network.py
@@ -466,7 +466,7 @@ class Network:
         # compare the patch to the discovered, current state, adding new or updated keys to pruned_patch
         pruned_patch = dict()
         for k in patch.keys():
-            if k not in RESOURCES[plural(type)].no_update_props and before_resource.get(k):
+            if k not in RESOURCES[plural(type)].no_update_props and k not in before_resource.keys():
                 if isinstance(patch[k], list):
                     if not set(before_resource[k]) == set(patch[k]):
                         pruned_patch[k] = list(set(patch[k]))

--- a/netfoundry/network_group.py
+++ b/netfoundry/network_group.py
@@ -243,21 +243,17 @@ class NetworkGroup:
             raise RuntimeError(f"got unexpected HTTP code {STATUS_CODES._codes[response_code][0].upper()} ({response_code}) and response {response.text}")
 
         try:
-            process_executions = resource['_links'].get('process-executions')
-            if isinstance(process_executions, list):
-                find_executions_url = process_executions[0]['href']
-            else:
-                find_executions_url = process_executions['href']
+            executions_link = resource['_links']['executions']['href']
             processes = list()
             process_id = None
-            for i in find_generic_resources(url=find_executions_url, headers=headers, embedded=NET_RESOURCES['process-executions']._embedded, proxies=self.proxies, verify=self.verify):
+            for i in find_generic_resources(url=executions_link, headers=headers, embedded=NET_RESOURCES['executions']._embedded, proxies=self.proxies, verify=self.verify):
                 processes.extend(i)
             for process in processes:
                 if process['name'].startswith('Create Network'):
                     process_id = process['id']
                     break
             if wait and process_id:
-                self.Networks.wait_for_process(process_id, RESOURCES["process-executions"].status_symbols['complete'], wait=wait, sleep=sleep)
+                self.Networks.wait_for_process(process_id, RESOURCES["executions"].status_symbols['complete'], wait=wait, sleep=sleep)
                 resource = self.get_resource_by_id(type="network", id=resource['id'])
             else:
                 self.logger.warning("not configured to wait or no process_id found in list of executions")

--- a/netfoundry/utility.py
+++ b/netfoundry/utility.py
@@ -557,6 +557,21 @@ RESOURCES = {
         status="state",
         status_symbols=PROCESS_STATUS_SYMBOLS,
     ),
+    'executions': ResourceType(
+        name='executions',
+        domain='network',
+        mutable=False,
+        embeddable=True,
+        status_symbols=PROCESS_STATUS_SYMBOLS,
+        abbreviation='ex',
+    ),
+    # 'processes': ResourceType(  # not a fully-fledged resource type because there is no "find processes" operation at this time
+    #     name='processes',
+    #     domain='network',
+    #     mutable=False,
+    #     embeddable=False,
+    #     status_symbols=PROCESS_STATUS_SYMBOLS,
+    # ),
     'regions': ResourceType(
         name='regions',
         domain='network',
@@ -770,10 +785,10 @@ def docstring_parameters(*args, **kwargs):
 
 
 RETRY_STRATEGY = Retry(
-    total=3,
-    status_forcelist=[413, 429, 503],
+    total=5,
+    status_forcelist=[404, 413, 429, 503],
     method_whitelist=["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"],
-    backoff_factor=1
+    backoff_factor=1.2
 )
 DEFAULT_TIMEOUT = 31  # seconds, Gateway Service waits 30s before responding with an error code e.g. 503 and
 # so waiting at least 31s is necessary to obtain that information

--- a/netfoundry/utility.py
+++ b/netfoundry/utility.py
@@ -786,9 +786,9 @@ def docstring_parameters(*args, **kwargs):
 
 RETRY_STRATEGY = Retry(
     total=5,
-    status_forcelist=[404, 413, 429, 503],
+    status_forcelist=[403, 404, 413, 429, 503],  # The API responds 403 and 404 for not-yet-existing executions for some async operations
     method_whitelist=["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"],
-    backoff_factor=1.2
+    backoff_factor=1
 )
 DEFAULT_TIMEOUT = 31  # seconds, Gateway Service waits 30s before responding with an error code e.g. 503 and
 # so waiting at least 31s is necessary to obtain that information


### PR DESCRIPTION
PATCH operations would silently fail because the method compares current / desired state to determine which properties require patching. If the current state has a property like `attributes: []` then the faulty logic would "prune" the key which value evaluates to False and therefore never patch property `attributes` with the desired value.

Another bug caused the first server-side page of network-groups to be fetched twice because of a faulty workaround for the API bug where network-groups server-side pages are 1-based instead of 0-based. 